### PR TITLE
chore(deps): harden Renovate automation

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -2,7 +2,7 @@ name: Renovate
 
 on:
   schedule:
-    - cron: '30 3 * * *' # 03:30 UTC, adjust if a different window is desired
+    - cron: '17 */6 * * *' # Every 6 hours; spread dependency CI load across the day.
   workflow_dispatch:
   push:
     branches:
@@ -11,6 +11,7 @@ on:
       - dev
     paths:
       - renovate.json
+      - .github/workflows/renovate.yaml
 
 permissions:
   contents: write
@@ -41,10 +42,12 @@ jobs:
           gh api rate_limit >/dev/null
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v46.1.20
+        uses: renovatebot/github-action@v46.2.5
         with:
           configurationFile: renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
           LOG_LEVEL: info
+          RENOVATE_CLONE_SUBMODULES: 'true'
+          RENOVATE_GIT_AUTHOR: 'MFSGA Renovate <193414067+MFSGA@users.noreply.github.com>'
           RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/renovate.json
+++ b/renovate.json
@@ -2,12 +2,19 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "default:automergeMinor",
-    "default:prHourlyLimitNone",
-    "default:preserveSemverRanges",
-    "default:rebaseStalePrs",
+    ":configMigration",
+    "security:minimumReleaseAgeNpm",
+    ":maintainLockFilesWeekly",
+    ":automergeMinor",
+    ":preserveSemverRanges",
+    ":rebaseStalePrs",
     "group:monorepos"
   ],
+  "dependencyDashboard": false,
+  "ignorePaths": ["ref/**", "backend/chimera-runtime/**"],
+  "platformAutomerge": false,
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 2,
   "packageRules": [
     {
       "matchManagers": ["npm"],
@@ -15,8 +22,7 @@
     },
     {
       "matchManagers": ["cargo"],
-      "rangeStrategy": "update-lockfile",
-      "platformAutomerge": false
+      "rangeStrategy": "update-lockfile"
     },
     {
       "groupName": "Oxc packages",
@@ -61,6 +67,5 @@
       "groupName": "Testing packages",
       "matchPackageNames": ["/vitest/", "/cypress/", "/wdio/"]
     }
-  ],
-  "prConcurrentLimit": 30
+  ]
 }


### PR DESCRIPTION
Configures Renovate for reliable submodule-aware Cargo updates, safer CI-gated automerge, lower PR concurrency, npm release-age protection, weekly lockfile maintenance, and a current Renovate GitHub Action.\n\nKey fixes:\n- clone backend/chimera-runtime so Cargo lockfile updates can resolve chimera-ipc\n- ignore submodule contents as Renovate-managed package roots\n- disable Dependency Dashboard while the current PAT lacks Issues write permission\n- disable platform-native automerge so Renovate waits for CI checks\n- cap open PRs at 10 and new PRs at 2/hour\n- run Renovate every 6 hours\n- set an owned Git author and update renovatebot/github-action to v46.2.5\n\nValidation:\n- renovate.json parses as JSON\n- git diff --check passes\n- initialized backend/chimera-runtime and cargo metadata resolves successfully